### PR TITLE
docs: replace all usages of Google cloud to AWS buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,13 @@ First, ensure that you have GNU Make installed, by running `brew install make`. 
 
 ## Downloading Datasets
 
-To download all datasets from Woodwell Google Cloud Platform (GCP) bucket, run `gmake sync-woodwell-to-local`. This command uses [rclone](https://rclone.org/you) to sync the netCDF files in the bucket to `data/woodwell`. The easiest way to install it is by running `brew install rclone`. You will need to authenticate `rclone` with Google. You can find an example config file [here](conf/rclone.conf).
-
-The GCP bucket link, [wcdi_production](https://console.cloud.google.com/storage/browser/wcdi_production), contains folders for each volume (such as `heat_module` and `water_module`). Each of these module folders contain folders to organize the dataset netCDF files by the type of climate models that Woodwell used to create them. For example, the RCM datasets that use the RegCM plus REMO ensemble of models are in a folder called `rcm_regcm_remo`.
+Download all datasets from the AWS bucket `global-pf-data-engineering`. The bucket contains folders for different version of the datasets. Each folder contains folders for each volume (such as `heat_module` and `water_module`). These module folders contain the dataset netCDF files that Woodwell team members create.
 
 All of the datasets and the maps we create from the datasets come from netCDF files containing latitude and longitude gridded point data with global coverage, excluding oceans except for areas near the coast and in most cases excluding polar regions. There are two resolutions of datasets that we use: Regionial Climate Model (RCM) and Global Circulation Model (GCM). The regional climate models we use are RegCM and REMO. They have a resolution of approximately 0.22° latitude and longitude (~25km) squared so they have many more data points and are much larger files than the GCM models, which have a resolution of about 2.5° latitude and longitude. The RCM maps are the maps we primarily use because they offer users a much higher resolution which tends to be more useful for most people who use the Probable Futures maps.
 
 ## Importing a Dataset
 
-To import a dataset to your local PostgreSQL database, make sure first you set up the loader locally by following the instructions [here](netcdfs/import/README.md). Note: you can skip `Google Cloud SDK` section, if you went though the steps of downloading datasets above.
+To import a dataset to your local PostgreSQL database, make sure first you set up the loader locally by following the instructions [here](netcdfs/import/README.md).
 
 Then, you should be to run the following commands to import a dataset:
 

--- a/conf/rclone.conf
+++ b/conf/rclone.conf
@@ -1,10 +1,3 @@
-[woodwell-gcp]
-type = google cloud storage
-object_acl = projectPrivate
-bucket_acl = projectPrivate
-location = us-east4
-# token =
-
 [pf-s3]
 type = s3
 provider = AWS
@@ -15,4 +8,3 @@ acl = authenticated-read
 server_side_encryption = AES256
 storage_class = STANDARD
 profile = probable-futures
-

--- a/netcdfs/import/README.md
+++ b/netcdfs/import/README.md
@@ -14,9 +14,9 @@ We are using the `xarray` module to load data. Then we convert `xarray` DataSets
 
 There's a section below, entitled [Datatypes and conversion](#Datatypes-and-conversions), which serves as a kind of pseudocontract between Postlight and Probable Futures/Woodwell. The basic idea is that:
 
-1) We will be on the lookout for new *units* in data. Degrees celsius, total days, percentage, are examples of units.
-2) When we find a new kind of unit, we will document the unit in our code and be extremely explicit about the type conversion.
-3) We'll share that with Probable Futures and Woodwell for their review.
+1. We will be on the lookout for new _units_ in data. Degrees celsius, total days, percentage, are examples of units.
+2. When we find a new kind of unit, we will document the unit in our code and be extremely explicit about the type conversion.
+3. We'll share that with Probable Futures and Woodwell for their review.
 
 In reality this isn't a ton of work, it's just way more explicit than we usually are, in the interest of creating code that is observable and can be validated.
 
@@ -42,10 +42,6 @@ If you're testing this out on your local machine you should also install postgis
 - Run `psql probable_futures -f util/temp.sql`
 
 That should give you all the database you need.
-
-#### Google Cloud SDK
-
-You need the Google Cloud SDK to download data. Read the [installation instructions](https://cloud.google.com/sdk/docs/install); basically you need to install it and run `gcloud init` to authenticate. You won't be able to download data unless you're approved; talk to an admin at Probable Futures to get the requisite credentials.
 
 #### Python
 
@@ -102,11 +98,6 @@ ford=# quit
 # You can run this next command as often as you like, but every time you do it blows away the coordinates table so you need to start over.
 $ psql probable_futures -f util/temp.sql
 
-# Log into Google cloud
-$ gcloud-sdk init
-
-$ ./bin/download.sh
-
 $ python pfimport.py --mutate --dbname probable_futures --dbuser ford --dbpassword ford --load-coordinates
 
 [output elided]
@@ -127,7 +118,6 @@ $ python pfimport.py --mutate --dbname probable_futures --dbuser ford --dbpasswo
 
 [output elided]
 ```
-
 
 ## Datatypes and conversions
 
@@ -244,6 +234,7 @@ datasets:
 ```
 
 ### Type conversion code
+
 ```python
 
 def stat_fmt(pandas_value, unit):

--- a/netcdfs/import/bin/download.sh
+++ b/netcdfs/import/bin/download.sh
@@ -1,1 +1,0 @@
-gsutil cp -r "gs://wcdi_production/" ./data/ ; 


### PR DESCRIPTION
We are not using the Google cloud to store the netCDF datasets. Instead they are now stored on AWS