### PR TITLE
sc-5616: create absolute version of change maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ python pfimport.py --mutate --dbname probable_futures --dbuser postgres --dbpass
 
 ## Creating Tilesets & Maps
 
-First, export the dataset that you want to create map for as geojson, by running `gmake data/mapbox/mts/$DATASET_ID.geojsonld`.
+First, export the dataset that you want to create map for as geojson, by running `gmake ../data/mapbox/mts/$DATASET_ID.geojsonld`.
 This will use `ogr2ogr` to fetch the specified dataset and save it to `data/mapbox/mts/`.
 
 Then, add a new entry for it in the list of datasets in [createTilesets.ts](vector-tiles/createTilesets.ts). Make sure to comment out the datasets that you don't want to create maps for, otherwise old tilesets will be replaced by new ones.

--- a/geojson/Makefile
+++ b/geojson/Makefile
@@ -50,16 +50,27 @@ data_3c_low, data_3c_mid, data_3c_high $\
 from pf_private.aggregate_pf_dataset_statistic_cells where dataset_id = ${*}
 endef
 
+# define EXPORT_QUERY_WITH_ABSOLUTE_VALUES_FOR_CHANGE_MAPS
+# select cell, $\
+# data_baseline_absolute_low, data_baseline_absolute_mid, data_baseline_absolute_high, $\
+# data_baseline_low, data_baseline_mid, data_baseline_high, $\
+# data_1c_low, data_1c_mid, data_1c_high, $\
+# data_1_5c_low, data_1_5c_mid, data_1_5c_high, $\
+# data_2c_low, data_2c_mid, data_2c_high, $\
+# data_2_5c_low, data_2_5c_mid, data_2_5c_high, $\
+# data_3c_low, data_3c_mid, data_3c_high $\
+# from pf_private.aggregate_pf_dataset_statistic_cells_with_absolute_values where dataset_id = ${*}
+# endef
+
 define EXPORT_QUERY_WITH_ABSOLUTE_VALUES_FOR_CHANGE_MAPS
 select cell, $\
-data_baseline_absolute_low, data_baseline_absolute_mid, data_baseline_absolute_high, $\
 data_baseline_low, data_baseline_mid, data_baseline_high, $\
 data_1c_low, data_1c_mid, data_1c_high, $\
 data_1_5c_low, data_1_5c_mid, data_1_5c_high, $\
 data_2c_low, data_2c_mid, data_2c_high, $\
 data_2_5c_low, data_2_5c_mid, data_2_5c_high, $\
 data_3c_low, data_3c_mid, data_3c_high $\
-from pf_private.aggregate_pf_dataset_statistic_cells_with_absolute_values where dataset_id = ${*}
+from pf_private.aggregate_pf_statistic_cells_change_to_absolute where dataset_id = ${*}
 endef
 
 define SELECT_QUERY
@@ -73,7 +84,7 @@ install: bundle ## Install all dependencies
 bundle: ## Install dependencies from Brewfile
 	brew bundle
 
-data/mapbox/mts/%.geojsonld: ## Export GeoJSONSeq from Database
+../data/mapbox/mts/%.geojsonld: ## Export GeoJSONSeq from Database
 	mkdir -p data/mapbox/mts
 	echo "Begining export of dataset ${*}"
 	$(info Using SQL Query: $(call SELECT_QUERY,${*}))

--- a/netcdfs/import/util/temp.sql
+++ b/netcdfs/import/util/temp.sql
@@ -460,3 +460,57 @@ from
   join pf_public.pf_grid_coordinates coords on stats.coordinate_hash = coords.md5_hash;
 
 comment on view pf_private.aggregate_pf_dataset_statistic_cells_with_absolute_values is E'View of aggregate dataset statistics joined with coordinate cells. Used to create change maps';
+
+CREATE OR REPLACE VIEW pf_private.aggregate_pf_statistics_change_to_absolute AS
+SELECT
+    dataset_id,
+    coordinate_hash,
+    MAX(CASE WHEN warming_scenario = '0.5' THEN low_value END) AS data_baseline_low,
+    MAX(CASE WHEN warming_scenario = '0.5' THEN mid_value END) AS data_baseline_mid,
+    MAX(CASE WHEN warming_scenario = '0.5' THEN high_value END) AS data_baseline_high,
+    MAX(CASE WHEN warming_scenario = '0.5' THEN low_value END) + 
+    MAX(CASE WHEN warming_scenario = '1.0' THEN low_value END) AS data_1c_low,
+    MAX(CASE WHEN warming_scenario = '0.5' THEN mid_value END) + 
+    MAX(CASE WHEN warming_scenario = '1.0' THEN mid_value END) AS data_1c_mid,
+    MAX(CASE WHEN warming_scenario = '0.5' THEN high_value END) + 
+    MAX(CASE WHEN warming_scenario = '1.0' THEN high_value END) AS data_1c_high,
+    MAX(CASE WHEN warming_scenario = '0.5' THEN low_value END) + 
+    MAX(CASE WHEN warming_scenario = '1.5' THEN low_value END) AS data_1_5c_low,
+    MAX(CASE WHEN warming_scenario = '0.5' THEN mid_value END) + 
+    MAX(CASE WHEN warming_scenario = '1.5' THEN mid_value END) AS data_1_5c_mid,
+    MAX(CASE WHEN warming_scenario = '0.5' THEN high_value END) + 
+    MAX(CASE WHEN warming_scenario = '1.5' THEN high_value END) AS data_1_5c_high,
+    MAX(CASE WHEN warming_scenario = '0.5' THEN low_value END) + 
+    MAX(CASE WHEN warming_scenario = '2.0' THEN low_value END) AS data_2c_low,
+    MAX(CASE WHEN warming_scenario = '0.5' THEN mid_value END) + 
+    MAX(CASE WHEN warming_scenario = '2.0' THEN mid_value END) AS data_2c_mid,
+    MAX(CASE WHEN warming_scenario = '0.5' THEN high_value END) + 
+    MAX(CASE WHEN warming_scenario = '2.0' THEN high_value END) AS data_2c_high,
+    MAX(CASE WHEN warming_scenario = '0.5' THEN low_value END) + 
+    MAX(CASE WHEN warming_scenario = '2.5' THEN low_value END) AS data_2_5c_low,
+    MAX(CASE WHEN warming_scenario = '0.5' THEN mid_value END) + 
+    MAX(CASE WHEN warming_scenario = '2.5' THEN mid_value END) AS data_2_5c_mid,
+    MAX(CASE WHEN warming_scenario = '0.5' THEN high_value END) + 
+    MAX(CASE WHEN warming_scenario = '2.5' THEN high_value END) AS data_2_5c_high,
+    MAX(CASE WHEN warming_scenario = '0.5' THEN low_value END) + 
+    MAX(CASE WHEN warming_scenario = '3.0' THEN low_value END) AS data_3c_low,
+    MAX(CASE WHEN warming_scenario = '0.5' THEN mid_value END) + 
+    MAX(CASE WHEN warming_scenario = '3.0' THEN mid_value END) AS data_3c_mid,
+    MAX(CASE WHEN warming_scenario = '0.5' THEN high_value END) + 
+    MAX(CASE WHEN warming_scenario = '3.0' THEN high_value END) AS data_3c_high
+FROM pf_public.pf_dataset_statistics
+GROUP BY dataset_id, coordinate_hash;
+
+comment on view pf_private.aggregate_pf_statistics_change_to_absolute is
+  E'View of aggregate dataset statistics across all warming scenarios. Used to create change maps.';
+
+
+create or replace view pf_private.aggregate_pf_statistic_cells_change_to_absolute as
+select
+  coords.cell,
+  stats.*
+from
+  pf_private.aggregate_pf_statistics_change_to_absolute stats
+  join pf_public.pf_grid_coordinates coords on stats.coordinate_hash = coords.md5_hash;
+
+comment on view pf_private.aggregate_pf_statistic_cells_change_to_absolute is E'View of aggregate dataset statistics joined with coordinate cells. Used to create change maps';

--- a/vector-tiles/createTilesets.ts
+++ b/vector-tiles/createTilesets.ts
@@ -42,14 +42,14 @@ const isTilesetPrivate = false;
 const debugTilesets = debug.extend("tilesets");
 
 const debugMTSUpload = debugTilesets.extend("upload");
-async function uploadTilesetGeoJSONSource(datasetId: string) {
+async function uploadTilesetGeoJSONSource(datasetId: string, datasetVersion: string) {
   debugMTSUpload("input %i", datasetId);
   let fileStream;
 
   if (appEnv === "local") {
     fileStream = datasetFile(datasetId);
   } else {
-    const key = `climate-data-geojson/${datasetId}.geojsonld`;
+    const key = `climate-data-geojson/v${datasetVersion}/${datasetId}.geojsonld`;
     const s3Client = new S3Client({});
 
     try {
@@ -243,7 +243,7 @@ async function processDataset(dataset: ParsedDataset) {
   // await wait(randomBetween(500, 5000));
 
   console.log(`${dataset.id}: Uploading GeoJSON tileset source...\n`);
-  const { id: sourceId } = await uploadTilesetGeoJSONSource(dataset.id);
+  const { id: sourceId } = await uploadTilesetGeoJSONSource(dataset.id, dataset.version);
 
   console.log(`${dataset.id}: Validating recipes...\n`);
   console.log("");

--- a/vector-tiles/lambdaHandler.mjs
+++ b/vector-tiles/lambdaHandler.mjs
@@ -23,8 +23,6 @@ export const handler = async (event, _context, callback) => {
     callback(null, response);
   } catch (error) {
     console.error("Error:", error);
-    response.message = "error";
-    response.body = "An error occurred during tileset creation.";
-    callback(null, response);
+    callback(null, { message: "error", body: "An error occurred during tileset creation." });
   }
 };


### PR DESCRIPTION
Create tilesets for maps that are absolute. 

(We would need to change the binning because the values would be different.)

[ticket](https://app.shortcut.com/probablefutures/story/5616/consider-create-absolute-versions-of-change-tilesets)