### PR TITLE
fix: missing param when importing netcdf

### DIFF
--- a/netcdfs/import/pfimport.py
+++ b/netcdfs/import/pfimport.py
@@ -342,6 +342,7 @@ def __main__(
                             dataset_id=cdf["dataset"],
                             grid=cdf["grid"],
                             unit=cdf["unit"],
+                            use_mean_for_mid=cdf["use_mean_for_mid"],
                         )
                     )
 
@@ -397,6 +398,7 @@ def __main__(
                             "dataset_id",
                             "grid",
                             "unit",
+                            "use_mean_for_mid",
                         ]
                     )
 

--- a/vector-tiles/createTilesets.ts
+++ b/vector-tiles/createTilesets.ts
@@ -314,12 +314,12 @@ async function processDataset(dataset: ParsedDataset) {
   }
 
   console.log(`${dataset.id}: Waiting on tileset jobs to finish...\n`);
+  const retryAfter = randomBetween(2000, 5000);
+
   if (jobIds.eastJobId && jobIds.westJobId) {
     const { eastJobId, westJobId } = jobIds;
     await waitForTilesetJobs({
-      // Using a random retry time here to prevent rate limiting when these
-      // requests are run in parallel.
-      retryAfter: randomBetween(2000, 5000),
+      retryAfter,
       datasetId: dataset.id,
       eastJobId,
       westJobId,
@@ -329,12 +329,12 @@ async function processDataset(dataset: ParsedDataset) {
     await waitForTilesetJob({
       jobId: jobIds.jobId,
       tilesetId: createTilesetId(dataset.id),
-      retryAfter: randomBetween(2000, 5000),
+      retryAfter,
     });
   }
 
   console.log(`${dataset.id}: Creating map style...\n`);
-  const body = await createStyle(dataset);
+  await createStyle(dataset);
 
   console.log(`${dataset.id}: Finished!\n`);
 }


### PR DESCRIPTION
This PR refactors the retry logic in processDataset to calculate the retryAfter interval once per dataset.

It also adds the missing `use_mean_for_mid` field when creating importing and processing the netcdf files
